### PR TITLE
Render page numbers and link

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/orbiting/poc-pdf#readme",
   "dependencies": {
-    "@react-pdf/core": "0.7.7-2",
+    "@react-pdf/core": "0.7.7-4",
     "apollo-fetch": "^0.7.0",
     "babel-preset-stage-0": "^6.24.1",
     "d3-array": "^1.2.1",

--- a/src/components/Document.js
+++ b/src/components/Document.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import { StyleSheet, Document, Page, Text, Font, View } from '@react-pdf/core'
 import { renderMdast } from 'mdast-react-render'
 import hyphenationCallback from '../lib/Hyphenation'
@@ -21,14 +21,51 @@ const styles = StyleSheet.create({
     marginBottom: 15,
     backgroundColor: '#000'
   },
-  footer: {
+  logo: {
     left: 40,
     bottom: 25,
     fontSize: 10,
     position: 'absolute',
     fontFamily: fontFamilies.serifTitle
+  },
+  path: {
+    left: 105,
+    bottom: 28,
+    fontSize: 8,
+    position: 'absolute',
+    fontFamily: fontFamilies.sansSerifRegular
+  },
+  numbers: {
+    right: 40,
+    bottom: 25,
+    fontSize: 10,
+    position: 'absolute',
+    fontFamily: fontFamilies.sansSerifRegular
   }
 })
+
+const renderArticleLink = article => ({ pageNumber, totalPages }) => {
+  if (
+    pageNumber === 1 ||
+    pageNumber === totalPages
+  ) {
+    return `republik.ch${article.content.meta.path}`
+  }
+
+  return ''
+}
+
+const renderPageNumbers = ({ pageNumber, totalPages }) => (
+  `${pageNumber} / ${totalPages}`
+)
+
+const Footer = ({ article }) => (
+  <Fragment>
+    <Text style={styles.logo} fixed>REPUBLIK</Text>
+    <Text style={styles.path} render={renderArticleLink(article)} fixed />
+    <Text style={styles.numbers} render={renderPageNumbers} fixed />
+  </Fragment>
+)
 
 const MdastDocument = ({ article }) => {
   if (article.meta.template !== 'article') {
@@ -72,9 +109,9 @@ const MdastDocument = ({ article }) => {
   return (
     <Document>
       <Page size='A4' style={styles.page} wrap>
-        <View fixed style={decoratorStyle} />
+        <View style={decoratorStyle} fixed />
         {mdast.props.children}
-        <Text fixed style={styles.footer}>REPUBLIK</Text>
+        <Footer article={article} />
       </Page>
     </Document>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,12 +78,12 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@react-pdf/core@0.7.7-2":
-  version "0.7.7-2"
-  resolved "https://registry.yarnpkg.com/@react-pdf/core/-/core-0.7.7-2.tgz#11f2c587b4de5f2147c6aee44635ed396012ab1b"
+"@react-pdf/core@0.7.7-4":
+  version "0.7.7-4"
+  resolved "https://registry.yarnpkg.com/@react-pdf/core/-/core-0.7.7-4.tgz#631c2011a90996f5e635675cec993a417581fd5d"
   dependencies:
     "@react-pdf/font-substitution" "1.0.3"
-    "@react-pdf/linebreaker" "1.0.1"
+    "@react-pdf/linebreaker" "1.0.2"
     "@react-pdf/textkit" "^0.1.0"
     blob-stream "^0.1.3"
     fbjs "^0.8.4"
@@ -91,7 +91,6 @@
     is-url "^1.2.2"
     lodash.groupby "^4.6.0"
     lodash.isfunction "^3.0.8"
-    lodash.isnan "^3.0.2"
     lodash.isnil "^4.0.0"
     lodash.merge "^4.6.1"
     lodash.pick "^4.4.0"
@@ -111,10 +110,11 @@
     "@react-pdf/pdfkit" "0.8.7"
     "@react-pdf/textkit" "^0.1.0"
 
-"@react-pdf/linebreaker@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@react-pdf/linebreaker/-/linebreaker-1.0.1.tgz#9219baa04a8b7ee5c29fa11ef0c8e88c0a79393e"
+"@react-pdf/linebreaker@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@react-pdf/linebreaker/-/linebreaker-1.0.2.tgz#818eeb49ad92dad9fb8e2fcc86df94041df5a2d1"
   dependencies:
+    "@react-pdf/textkit" "0.1.0"
     hyphenation.en-us "^0.2.1"
     hypher "^0.2.5"
 
@@ -126,7 +126,7 @@
     linebreak "^0.3.0"
     png-js ">=0.1.0"
 
-"@react-pdf/textkit@^0.1.0":
+"@react-pdf/textkit@0.1.0", "@react-pdf/textkit@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@react-pdf/textkit/-/textkit-0.1.0.tgz#e75f1c3fb9bf4aac8511d213a01172fe8d2c9b41"
   dependencies:
@@ -3600,10 +3600,6 @@ lodash.groupby@^4.6.0:
 lodash.isfunction@^3.0.8:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
-
-lodash.isnan@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash.isnan/-/lodash.isnan-3.0.2.tgz#82ed04a5f9ea8bd6226d0c26af0cac32f4507745"
 
 lodash.isnil@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
- Renders page numbers in the format `${pageNumber}/${totalPages}`. Fixes #53 
- Renders article link only on first and last page. Fixes #54 

<img width="873" alt="screen shot 2018-04-24 at 12 59 01 pm" src="https://user-images.githubusercontent.com/5600341/39199217-4d6d2372-47bf-11e8-9255-116198f146ef.png">
