### PR TITLE
better default pull quote size, support explicit narrow size

### DIFF
--- a/fixtures/elements.json
+++ b/fixtures/elements.json
@@ -957,6 +957,31 @@
               {
                 "children": [
                   {
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "«Or be narrow aka centered»"
+                      }
+                    ],
+                    "type": "paragraph"
+                  },
+                  {
+                    "children": [
+                      {
+                        "type": "text",
+                        "value": "Thomas"
+                      }
+                    ],
+                    "type": "paragraph"
+                  }
+                ],
+                "data": {"size": "narrow"},
+                "identifier": "QUOTE",
+                "type": "zone"
+              },
+              {
+                "children": [
+                  {
                     "type": "text",
                     "value": "infobox"
                   }

--- a/src/components/PullQuote.js
+++ b/src/components/PullQuote.js
@@ -29,7 +29,7 @@ const styles = StyleSheet.create({
 })
 
 const PullQuote = ({ size, hasFigure, children }) => {
-  const containerClass = !hasFigure && styles.narrowContainer
+  const containerClass = !hasFigure && size === 'narrow' && styles.narrowContainer
   const figure = Children.toArray(children).filter(child => child.type === PullQuoteFigure)
   const childs = Children.toArray(children).filter(child => child.type !== PullQuoteFigure)
 


### PR DESCRIPTION
<img width="632" alt="screen shot 2018-04-30 at 14 46 48" src="https://user-images.githubusercontent.com/410211/39427789-5a99fb4a-4c85-11e8-976c-e64f9fd1f4c6.png">

Got internal feedback that the default narrow size is not ideal. So now defaulting to column width and supporting the explicit narrow size.