### PR TITLE
replace throng with regiment

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-apollo": "^2.0.4",
     "react-dom": "^16.2.0",
     "regenerator-runtime": "^0.11.1",
-    "throng": "^4.0.0"
+    "regiment": "https://github.com/orbiting/regiment"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/test/renderToFile.js
+++ b/test/renderToFile.js
@@ -39,7 +39,6 @@ function fetchDoc (doc) {
     })
     .catch(err => {
       console.error('Broken', doc.meta.path, err)
-      process.exit()
     })
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3635,10 +3635,6 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash.defaults@^4.0.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
-
 lodash.groupby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
@@ -4576,6 +4572,10 @@ regexpu-core@^2.0.0:
     regjsgen "^0.2.0"
     regjsparser "^0.1.4"
 
+"regiment@https://github.com/orbiting/regiment":
+  version "0.0.4"
+  resolved "https://github.com/orbiting/regiment#dfdbe1a73866a7c20fe741a17d89ba27cc9c095e"
+
 registry-auth-token@^3.0.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"
@@ -5242,12 +5242,6 @@ term-size@^1.2.0:
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
-
-throng@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/throng/-/throng-4.0.0.tgz#983c6ba1993b58eae859998aa687ffe88df84c17"
-  dependencies:
-    lodash.defaults "^4.0.1"
 
 through2@^2.0.0, through2@~2.0.3:
   version "2.0.3"


### PR DESCRIPTION
[regiment](https://github.com/HustleInc/regiment) allows to gracefully restart when memory exceeds a threshold.

In our case the threshold is `WEB_MEMORY` (the memory of one worker, auto set by heroku but customisable).