### PR TITLE
Adujst page margins for A5 pages

### DIFF
--- a/src/components/Center.js
+++ b/src/components/Center.js
@@ -3,7 +3,10 @@ import { View, StyleSheet } from '@react-pdf/core'
 
 const styles = StyleSheet.create({
   center: {
-    paddingHorizontal: 90
+    paddingHorizontal: 90,
+    '@media max-width: 420': {
+      paddingHorizontal: 30
+    }
   }
 })
 

--- a/src/components/TitleBlock.js
+++ b/src/components/TitleBlock.js
@@ -6,7 +6,10 @@ const styles = StyleSheet.create({
   titleblock: {
     marginTop: 30,
     marginBottom: 40,
-    paddingHorizontal: 90
+    paddingHorizontal: 90,
+    '@media max-width: 420': {
+      paddingHorizontal: 30
+    }
   },
   formatTitle: {
     fontSize: 12,


### PR DESCRIPTION
This PR adds media-queries to render the document as the image:

<img width="423" alt="screen shot 2018-05-11 at 5 45 59 pm" src="https://user-images.githubusercontent.com/5600341/39946172-8c430ada-5543-11e8-9cf2-271dc4652e5d.png">

However, the ticket says something about an url param that I didn't get. Should we accept passing the page size as param? This was very quick to do. We can also try with % margins if we want to support a bunch of different sizes

cc/ @tpreusse 

Fixes #107 