### PR TITLE
Don't center tiny cover figures

### DIFF
--- a/src/templates/Article/index.js
+++ b/src/templates/Article/index.js
@@ -178,7 +178,7 @@ const figure = {
       return null
     }
 
-    if (isCover && aspectRatio && aspectRatio < 0.9) {
+    if (isCover && aspectRatio && aspectRatio < 0.9 && props.size !== 'tiny') {
       return (
         <Center>
           <Figure {...props} />


### PR DESCRIPTION
New cover image centering (introduced in #114 ) causes this on images with `size=tiny`:

<img width="825" alt="screen shot 2018-05-16 at 11 32 21 am" src="https://user-images.githubusercontent.com/5600341/40123873-94f5e4aa-58fd-11e8-8f5a-53a7680beb3a.png">

Since the centering is not always happening (only for portrait images), adjusting the `tiny` styles won't work well in all cases, so I think what's best in this case is just checking for `size !== tiny` 

Final result:

<img width="817" alt="screen shot 2018-05-16 at 11 39 50 am" src="https://user-images.githubusercontent.com/5600341/40123995-e2486d0e-58fd-11e8-90cc-edf067f356d9.png">

