### PR TITLE
fix(List): indent like on web

### DIFF
--- a/src/components/List.js
+++ b/src/components/List.js
@@ -11,12 +11,13 @@ const styles = StyleSheet.create({
   listitem: {
     flex: 1,
     fontSize: 10,
+    paddingLeft: 15,
     textAlign: 'justify',
     fontFamily: fontFamilies.serifRegular
   },
   bulletPoint: {
     width: 30,
-    left: -37,
+    left: -20,
     fontSize: 10,
     textAlign: 'right',
     position: 'absolute',


### PR DESCRIPTION
Mirrors https://github.com/orbiting/styleguide/pull/222 on PDF.

## Before
<img width="832" alt="screenshot 2019-02-27 at 18 05 42" src="https://user-images.githubusercontent.com/23520051/53508834-d72eb000-3aba-11e9-820b-f0d03d4048cd.png">
<img width="820" alt="screenshot 2019-02-27 at 18 07 25" src="https://user-images.githubusercontent.com/23520051/53508835-d72eb000-3aba-11e9-9eb9-c743aa0eaa87.png">

## After
<img width="831" alt="screenshot 2019-02-27 at 18 05 10" src="https://user-images.githubusercontent.com/23520051/53508862-e281db80-3aba-11e9-8cfa-bd72e4f903c3.png">
<img width="821" alt="screenshot 2019-02-27 at 18 05 22" src="https://user-images.githubusercontent.com/23520051/53508863-e31a7200-3aba-11e9-8ad3-aef79f4ea5f0.png">
